### PR TITLE
Support Virtual Getters

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,8 +81,6 @@ function applyGettersToDoc(schema, doc) {
   for (let i = 0; i < virtualKeys.length; ++i) {
     const virtualPath = virtualKeys[i];
     const virtualType = schema.virtuals[virtualPath];
-    if (virtualType.getters.length > 1) {
-      mpath.set(virtualPath, virtualType.applyGetters(mpath.get(virtualPath, doc), doc, true), doc);
-    }
+    mpath.set(virtualPath, virtualType.applyGetters(mpath.get(virtualPath, doc), doc, true), doc);
   }
 }

--- a/index.js
+++ b/index.js
@@ -80,6 +80,8 @@ function applyGettersToDoc(schema, doc) {
   for (let i = 0; i < virtualKeys.length; ++i) {
     const virtualPath = virtualKeys[i];
     const virtualType = schema.virtuals[virtualPath];
-    mpath.set(virtualPath, virtualType.applyGetters(mpath.get(virtualPath, doc), doc, true), doc);
+    if (virtualType.getters.length > 1) {
+      mpath.set(virtualPath, virtualType.applyGetters(mpath.get(virtualPath, doc), doc, true), doc);
+    }
   }
 }

--- a/index.js
+++ b/index.js
@@ -75,4 +75,11 @@ function applyGettersToDoc(schema, doc) {
   schema.eachPath((path, schematype) => {
     mpath.set(path, schematype.applyGetters(mpath.get(path, doc), doc, true), doc);
   });
+
+  // Handle getters on virtual fields
+  for (let i = 0; i < virtualKeys.length; ++i) {
+    const virtualPath = virtualKeys[i];
+    const virtualType = schema.virtuals[virtualPath];
+    mpath.set(virtualPath, virtualType.applyGetters(mpath.get(virtualPath, doc), doc, true), doc);
+  }
 }

--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ function applyGettersToDoc(schema, doc) {
   });
 
   // Handle getters on virtual fields
+  const virtualKeys = Object.keys(schema.virtuals);
   for (let i = 0; i < virtualKeys.length; ++i) {
     const virtualPath = virtualKeys[i];
     const virtualType = schema.virtuals[virtualPath];

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,4 @@
-  
+
 'use strict';
 
 const assert = require('assert');
@@ -62,5 +62,30 @@ describe('mongoose-lean-getters', function() {
     const docs = await Model.find().lean({ getters: true });
 
     assert.equal(docs[0].name, 'test123');
+  });
+
+  it('calls getters on virtual populate fields', async function() {
+    const schema = mongoose.Schema({
+      name: {
+        type: String,
+        get: v => v + '123'
+      }
+    });
+    const virtual = schema.virtual('virt', {
+      ref: 'VirtualPopulate',
+      localField: '_id',
+      foreignField: 'name',
+    });
+    virtual.getters.unshift(function() { return 5; });
+    schema.plugin(mongooseLeanGetters);
+
+    const Model = mongoose.model('VirtualPopulate', schema);
+
+    await Model.deleteMany({});
+    await Model.create({ name: 'test' });
+
+    const docs = await Model.find().lean({ getters: true });
+
+    assert.equal(docs[0].virt, 5);
   });
 });


### PR DESCRIPTION
Previously, only getters on "real" scheam fields we added. Leaving off getter for virtual and virtually populated fields. This adds those back.