### PR TITLE
Support for renamed function Query.prototype.transform added in pre find hook. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,11 @@ module.exports = function mongooseLeanGetters(schema) {
         fn.call(this, res);
         return res;
       });
+    } else if (typeof this.transform === 'function') {
+      this.transform((res) => {
+        fn.call(this, res);
+        return res;
+      });
     } else {
       this.options.transform = (res) => {
         fn.call(this, res);


### PR DESCRIPTION
**Summary**

I find out that `Query.prototype.map` was renamed to `Query.prototype.transform` in mongoose 6 (see: https://github.com/Automattic/mongoose/commit/1e485dfdd1ed89235ce68f0f413bce15085c2052). 
I added additional check for `this.transform` and kept `this.map` to ensure backward compatibility.
Resolves #6.

