### PR TITLE
fix: call nested getters if nesting level > 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function applyGetters(schema, res, path) {
     for (let i = 0; i < schema.childSchemas.length; ++i) {
       const childPath = path ? path + '.' + schema.childSchemas[i].model.path : schema.childSchemas[i].model.path;
       const _schema = schema.childSchemas[i].schema;
-      const doc = mpath.get(childPath, res);
+      const doc = mpath.get(schema.childSchemas[i].model.path, res);
       if (doc == null) {
         continue;
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

The nested getters aren't called if nesting LVL > 1. Tests are provided.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->