### PR TITLE
fix: add double pipe to mongoose peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "mongoose": "6.x"
   },
   "peerDependencies": {
-    "mongoose": ">= 5.11.0 | 6.x"
+    "mongoose": ">= 5.11.0 || 6.x"
   },
   "author": "Valeri Karpov <val@karpov.io>",
   "license": "Apache 2.0",


### PR DESCRIPTION
**Summary**

Fixes the issue described in #18 by using a double pipe instead of a single pipe. I tested this on my local project and it worked.
