### PR TITLE
feat: apply getters to schemas with discriminator

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,16 @@ function applyGettersMiddleware(schema) {
   };
 }
 
+function getSchemaForRes(schema, res) {
+  if (!schema.discriminatorMapping || !schema.discriminatorMapping.key) {
+    return schema;
+  }
+
+  const discriminatorValue = res[schema.discriminatorMapping.key];
+  const childSchema = schema.discriminators[discriminatorValue];
+  return childSchema;
+}
+
 function applyGetters(schema, res, path) {
   if (res == null) {
     return;
@@ -44,10 +54,12 @@ function applyGetters(schema, res, path) {
     if (Array.isArray(res)) {
       const len = res.length;
       for (let i = 0; i < len; ++i) {
-        applyGettersToDoc.call(this, schema, res[i], this._fields, path);
+        const schemaForRes = getSchemaForRes(schema, res[i]);
+        applyGettersToDoc.call(this, schemaForRes, res[i], this._fields, path);
       }
     } else {
-      applyGettersToDoc.call(this, schema, res, this._fields, path);
+      const schemaForRes = getSchemaForRes(schema, res);
+      applyGettersToDoc.call(this, schemaForRes, res, this._fields, path);
     }
 
     for (let i = 0; i < schema.childSchemas.length; ++i) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -229,7 +229,7 @@ describe('mongoose-lean-getters', function() {
     assert.equal(res.items[0].text, 't amet');
   });
 
-  it('should call nested getters on schemas with discriminator', async function() {
+  it('should call getters on schemas with discriminator', async function() {
     const options = { discriminatorKey: 'kind' };
 
     const eventSchema = new mongoose.Schema({ time: Date }, options);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

When schemas are created using inheritance with a discriminator field, the getters are not applied to the fields that only occur in the discriminator schema.

**Examples**

See the test `should call getters on schemas with discriminator`