### PR TITLE
fix: correctly get schema for each element of a discriminated array

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function applyGetters(schema, res, path) {
 }
 
 function getSchemaForDoc(schema, res) {
-  if (!schema.discriminatorMapping || !schema.discriminatorMapping.key) {
+  if (!schema.discriminatorMapping || !schema.discriminatorMapping.key || !schema.discriminators) {
     return schema;
   }
 
@@ -81,14 +81,17 @@ function applyGettersToDoc(schema, doc, fields, prefix) {
     return;
   }
 
-  const schemaForDoc = getSchemaForDoc(schema, doc);
-
   if (Array.isArray(doc)) {
     for (let i = 0; i < doc.length; ++i) {
-      applyGettersToDoc.call(this, schemaForDoc, doc[i], fields, prefix);
+      const currentDoc = doc[i];
+      if (currentDoc == null) continue;
+      const schemaForDoc = getSchemaForDoc(schema, currentDoc);
+      applyGettersToDoc.call(this, schemaForDoc, currentDoc, fields, prefix);
     }
     return;
   }
+
+  const schemaForDoc = getSchemaForDoc(schema, doc);
 
   schemaForDoc.eachPath((path, schematype) => {
     const pathWithPrefix = prefix ? prefix + '.' + path : path;


### PR DESCRIPTION
Also do not attempt to get the schema for null/undefined docs

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->
After updating the package to the latest version (1.1.0) it started failing when an empty array contained discriminated documents. It would get the child schema using the array as the document instead of an element of the array so it would end up with an undefined schema.

With this change it now gets the schema for each document in the array (unless it is null/undefined) and will also not break if a schema has a discriminator mapping key but no discriminators object (which happens when the schema is configured the way it is in the test).

**Examples**
I have included a new test, `should work on schemas with discriminators in arrays`, that failed before but passes now.
<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
