### PR TITLE
Fix: Handle discriminators with explicit values

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,11 @@ function getSchemaForDoc(schema, res) {
   }
 
   const discriminatorValue = res[schema.discriminatorMapping.key];
-  const childSchema = schema.discriminators[discriminatorValue];
+  const childSchema = Object.entries(schema.discriminators).find(([modelName, childSchema]) => {
+    // Match against an explicit discriminator value if present
+    const matchValue = childSchema.discriminatorMapping.value || modelName;
+    return discriminatorValue === matchValue;
+  })[1];
   return childSchema;
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -249,4 +249,30 @@ describe('mongoose-lean-getters', function() {
 
     assert.equal(docs[0].url, 'https://www.test.com discriminator field');
   });
+  it('should call getters on schemas with discriminator using explicit value', async function() {
+    const options = { discriminatorKey: 'kind' };
+
+    const eventSchema = new mongoose.Schema({ time: Date }, options);
+    eventSchema.plugin(mongooseLeanGetters);
+    const Event = mongoose.model('Event2', eventSchema);
+
+    const ClickedLinkEvent = Event.discriminator('ClickedLink2',
+      new mongoose.Schema({
+        url: { type: String, get: v => v + ' discriminator field' }
+      }, options),
+      {
+        value: 'ExplicitClickedLink'
+      }
+    );
+
+    await ClickedLinkEvent.deleteMany({});
+    await ClickedLinkEvent.create({
+      url: 'https://www.test.com'
+    });
+
+    // Should not throw "Cannot read properties of undefined (reading 'eachPath')"
+    const docs = await ClickedLinkEvent.find().lean({ getters: true });
+
+    assert.equal(docs[0].url, 'https://www.test.com discriminator field');
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

When using discriminators with explicit values (e.g., `Base.discriminator('Child', ChildSchema, 'ExplicitValue')`), the child schema can't be resolved correctly leading to an error "Cannot read properties of undefined (reading 'eachPath')" when using lean getters.

This change resolves the child schema using its explicit discriminator value if present, otherwise using its model name as is the default behaviour.

Related to #26 

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
Added test `should call getters on schemas with discriminator using explicit value`
