### PR TITLE
Add support for findOneAndReplace

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = function mongooseLeanGetters(schema) {
   schema.post('findOne', fn);
   schema.post('findOneAndUpdate', fn);
   schema.post('findOneAndDelete', fn);
+  schema.post('findOneAndReplace', fn);
 };
 
 function applyGettersMiddleware(schema) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -348,6 +348,6 @@ describe('mongoose-lean-getters', function() {
     });
     const doc = await Test.findOneAndReplace({ _id: entry._id }, entry).lean({ getters: true });
     assert.equal(typeof doc.field, 'string');
-    assert.equal(doc.field, '1337');
+    assert.strictEqual(doc.field, '1337');
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -330,4 +330,24 @@ describe('mongoose-lean-getters', function() {
     assert.strictEqual(user.name, 'ONE');
     assert.deepStrictEqual(foundUser.emails, ['TWO', 'THREE']);
   });
+
+  it('should work with findOneAndReplace (gh-31)', async function() {
+    const testSchema = new mongoose.Schema({
+      field: Number,
+    });
+    testSchema.plugin(mongooseLeanGetters);
+
+    testSchema.path('field').get(function(field) {
+      return field.toString();
+    });
+    const Test = mongoose.model('gh-31', testSchema);
+
+    await Test.deleteMany({});
+    const entry = await Test.create({
+      field: 1337
+    });
+    const doc = await Test.findOneAndReplace({ _id: entry._id }, entry).lean({ getters: true });
+    assert.equal(typeof doc.field, 'string');
+    assert.equal(doc.field, '1337');
+  });
 });


### PR DESCRIPTION
findOneAndReplace is currently not supported. This is required since a change in mongoose (commit 0caeb6b2e8428cb56573b75212ddb7c186c2725d) swapped findOneAndUpdate with the overwrite option set to use findOneAndReplace which is not supported by mongoose-lean-getters.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

When you use the overwrite option with findOneAndUpdate / findOneAndReplace the getters will not be applied to the schema.

**Examples**

We have a findOneAndReplace call with lean({getters: true}) specified. We have fields we want to convert from an objectId back to a string however the transfor is not applied.
