### PR TITLE
Fix errors on null value array types

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,16 +124,17 @@ function applyGettersToDoc(schema, doc, fields, prefix) {
 
     const pathExists = mpath.has(path, doc);
     if (pathExists) {
-      if (schematype.$isMongooseArray && !schematype.$isMongooseDocumentArray) {
+      const val = schematype.applyGetters(mpath.get(path, doc), doc, true);
+      if (val && schematype.$isMongooseArray && !schematype.$isMongooseDocumentArray) {
         mpath.set(
           path,
-          schematype.applyGetters(mpath.get(path, doc), doc, true).map(subdoc => {
+          val.map(subdoc => {
             return schematype.caster.applyGetters(subdoc, doc);
           }),
           doc
         );
       } else {
-        mpath.set(path, schematype.applyGetters(mpath.get(path, doc), doc, true), doc);
+        mpath.set(path, val, doc);
       }
     }
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -45,6 +45,22 @@ describe('mongoose-lean-getters', function() {
     assert.equal(doc.arr[0].test, 'baz');
   });
 
+  it('with nulled array', async function() {
+    const schema = mongoose.Schema({
+      arr: [String]
+    });
+    schema.plugin(mongooseLeanGetters);
+
+    const Model = mongoose.model('withNulledArray', schema);
+
+    await Model.deleteMany({});
+    await Model.create({ arr: null });
+
+    const doc = await Model.findOne().lean({ getters: true });
+
+    assert.equal(doc.arr, null);
+  });
+
   it('only calls getters once with find() (gh-1)', async function() {
     const schema = mongoose.Schema({
       name: {


### PR DESCRIPTION
**Summary**

mongoose queries error when processing a record which contains null as a value of an Array schema type.

```
TypeError: Cannot read properties of null (reading 'map')
    at /mongoose-test/node_modules/mongoose-lean-getters/index.js:130:67
    at Schema.eachPath (/mongoose-test/node_modules/mongoose/lib/schema.js:1569:5)
    at model.Query.applyGettersToDoc (/mongoose-test/node_modules/mongoose-lean-getters/index.js:110:16)
    at model.Query.applyGetters (/mongoose-test/node_modules/mongoose-lean-getters/index.js:51:25)
    at model.Query.<anonymous> (/mongoose-test/node_modules/mongoose-lean-getters/index.js:36:18)
    at next (/mongoose-test/node_modules/kareem/index.js:268:35)
    at Kareem.execPost (/mongoose-test/node_modules/kareem/index.js:296:3)
    at /mongoose-test/node_modules/mongoose/lib/query.js:4380:28
    at new Promise (<anonymous>)
    at _executePostHooks (/mongoose-test/node_modules/mongoose/lib/query.js:4377:10)
```

With this change we check for non-null after running possible array getters, but before running the for-each-element .map(). If the value is indeed null, we'll bail out of processing array elements, instead just continuing with the non-array codepath.

Fixes #35.
