### PR TITLE
fix: allow array getters to return non-arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,11 +125,15 @@ function applyGettersToDoc(schema, doc, fields, prefix) {
     const pathExists = mpath.has(path, doc);
     if (pathExists) {
       if (schematype.$isMongooseArray && !schematype.$isMongooseDocumentArray) {
+        // A getter may return a non-array
+        const got = schematype.applyGetters(mpath.get(path, doc), doc, true);
+        const val = Array.isArray(got) ? got.map(subdoc => {
+          return schematype.caster.applyGetters(subdoc, doc);
+        }) : schematype.caster.applyGetters(got, doc);
+
         mpath.set(
           path,
-          schematype.applyGetters(mpath.get(path, doc), doc, true).map(subdoc => {
-            return schematype.caster.applyGetters(subdoc, doc);
-          }),
+          val,
           doc
         );
       } else {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -385,7 +385,7 @@ describe('mongoose-lean-getters', function() {
     assert.strictEqual(doc.field, '1337');
   });
 
-  it('should should allow getters to transform return type', async function() {
+  it('should should allow array getters to return non-arrays', async function() {
     const userSchema = new mongoose.Schema({
       emails: {
         type: [String],
@@ -395,12 +395,14 @@ describe('mongoose-lean-getters', function() {
       }
     });
     userSchema.plugin(mongooseLeanGetters);
-    const User = mongoose.model('transform-arrays', userSchema);
+    const User = mongoose.model('gh-37-transform-arrays', userSchema);
 
     const variants = [
       { sourceVal: 'foo', expectedVal: 'foo' },
       { sourceVal: ['foo'], expectedVal: 'foo' },
       { sourceVal: ['foo', 'bar'], expectedVal: ['foo', 'bar'] },
+      { sourceVal: [], expectedVal: undefined },
+      { sourceVal: null, expectedVal: undefined },
       { sourceVal: undefined, expectedVal: undefined },
     ];
 
@@ -410,8 +412,9 @@ describe('mongoose-lean-getters', function() {
         await user.save();
 
         const foundUser = await User.findById(user._id).lean({ getters: true });
-        assert.deepStrictEqual(user.emails, expectedVal, `user did not have expected value { sourceVal: ${sourceVal}, expectedVal: ${expectedVal} }`);
-        assert.deepStrictEqual(foundUser.emails, expectedVal, `foundUser did not have expected value { sourceVal: ${sourceVal}, expectedVal: ${expectedVal}`);
+        const stringified = JSON.stringify({ sourceVal, expectedVal });
+        assert.deepStrictEqual(user.emails, expectedVal, `user did not have expected value ${stringified}`);
+        assert.deepStrictEqual(foundUser.emails, expectedVal, `foundUser did not have expected value ${stringified}`);
       })
     );
   });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Array getters should be allowed to return non-arrays.
This fixes #37 and #36
