### PR TITLE
fix: allow non-discriminated documents be retrieved

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,9 @@ function getSchemaForDoc(schema, res) {
       break;
     }
   }
-  return childSchema;
+
+  // If no discriminator schema found, return the root schema (#39)
+  return childSchema || schema;
 }
 
 function applyGettersToDoc(schema, doc, fields, prefix) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -395,7 +395,7 @@ describe('mongoose-lean-getters', function() {
     // Simply retrieving the non-discriminated document causes the error
     await assert.doesNotReject(async() => {
       const entry = await BaseModel.create({ foo: 'foo' });
-      await BaseModel.findById({ _id: entry._id }).lean({ getters: true });
+      await BaseModel.findById(entry._id).lean({ getters: true });
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -384,4 +384,18 @@ describe('mongoose-lean-getters', function() {
     assert.equal(typeof doc.field, 'string');
     assert.strictEqual(doc.field, '1337');
   });
+
+  it('should allow non-discriminated documents to be retrieved (#39)', async() => {
+    const baseSchema = new mongoose.Schema({ foo: String });
+    baseSchema.plugin(mongooseLeanGetters);
+
+    const BaseModel = mongoose.model('BaseModel-gh-39', baseSchema);
+    BaseModel.discriminator('Custom', new mongoose.Schema({}));
+
+    // Simply retrieving the non-discriminated document causes the error
+    await assert.doesNotReject(async() => {
+      const entry = await BaseModel.create({ foo: 'foo' });
+      await BaseModel.findById({ _id: entry._id }).lean({ getters: true });
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

This allows models with discriminators to create and retrieve non-discriminated documents. This closes #39.

**Examples**

Please see code example in the linked issue or the new test written for this PR.

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
