### PR TITLE
feat: allow default lean options plugin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,29 @@ await Model.create({ name: 'Captain Jean-Luc Picard' });
 const doc = await Model.findOne().lean({ getters: true });
 doc.name; // 'Picard'
 ```
+
+You may also set the default lean options to always use getters:
+
+```javascript
+const mongoose = require('mongoose');
+const mongooseLeanGetters = require('mongoose-lean-getters');
+
+const schema = mongoose.Schema({
+  name: {
+    type: String,
+    // Get the last 6 characters of the string
+    get: v => v.slice(-6)
+  }
+});
+// Set the default options for all lean queries
+schema.plugin(mongooseLeanGetters, { defaultLeanOptions: { getters: true }});
+
+await Model.create({ name: 'Captain Jean-Luc Picard' });
+
+const doc = await Model.findOne().lean();
+doc.name; // 'Picard'
+
+// You may also set getters: false at call time
+const doc2 = await Model.findOne().lean({ getters: false });
+doc2.name; // 'Captain Jean-Luc Picard'
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@
 
 declare module 'mongoose-lean-getters' {
   import mongoose = require('mongoose');
-  export default function mongooseLeanGetters(schema: mongoose.Schema<any, any, any, any>, opts?: any): void;
-  export function mongooseLeanGetters(schema: mongoose.Schema<any, any, any, any>, opts?: any): void;
+  export type LeanGettersOptions = { defaultLeanOptions?: { getters: boolean } };
+  export default function mongooseLeanGetters(schema: mongoose.Schema<any, any, any, any>, opts?: LeanGettersOptions): void;
+  export function mongooseLeanGetters(schema: mongoose.Schema<any, any, any, any>, opts?: LeanGettersOptions): void;
 }

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function applyGetters(schema, res, path) {
     return;
   }
   const { defaultLeanOptions } = this._mongooseLeanGettersOptions;
-  const shouldCallGetters = this._mongooseOptions?.lean?.getters ?? defaultOptions?.getters ?? false;
+  const shouldCallGetters = this._mongooseOptions?.lean?.getters ?? defaultLeanOptions?.getters ?? false;
 
   if (shouldCallGetters) {
     if (Array.isArray(res)) {

--- a/index.js
+++ b/index.js
@@ -43,11 +43,7 @@ function applyGetters(schema, res, path) {
     return;
   }
   const { defaultLeanOptions } = this._mongooseLeanGettersOptions;
-  const shouldCallGetters = this._mongooseOptions.lean && (
-    this._mongooseOptions.lean.getters ||
-    // Allow the default options to be overridden with `.lean({ getters: false })`
-    (defaultLeanOptions && defaultLeanOptions.getters && this._mongooseOptions.lean.getters !== false)
-  );
+  const shouldCallGetters = this._mongooseOptions?.lean?.getters ?? defaultOptions?.getters ?? false;
 
   if (shouldCallGetters) {
     if (Array.isArray(res)) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -384,4 +384,22 @@ describe('mongoose-lean-getters', function() {
     assert.equal(typeof doc.field, 'string');
     assert.strictEqual(doc.field, '1337');
   });
+
+  it('allows defaultLeanOptions to be set and overridden at call time (#33)', async() => {
+    const testSchema = new mongoose.Schema({
+      field: {
+        type: String,
+        get(val) { return `${val}-suffix`; },
+      }
+    });
+    testSchema.plugin(mongooseLeanGetters, { defaultLeanOptions: { getters: true } });
+
+    const TestModel = mongoose.model('gh-33', testSchema);
+    const entry = await TestModel.create({ field: 'value' });
+    const doc1 = await TestModel.findById(entry._id).lean();
+    assert.equal(doc1.field, 'value-suffix');
+
+    const doc2 = await TestModel.findById(entry._id).lean({ getters: false });
+    assert.equal(doc2.field, 'value');
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

This allows setting `{ getters: true }` at a plugin level. This can be overridden at call time to disable getters if need be. Closes #33. 

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

```js
const testSchema = new mongoose.Schema({
  field: {
    type: String,
    get(val) { return `${val}-suffix`; },
  }
});
testSchema.plugin(mongooseLeanGetters, { defaultLeanOptions: { getters: true } });

const TestModel = mongoose.model('gh-33', testSchema);
const entry = await TestModel.create({ field: 'value' });
const doc1 = await TestModel.findById(entry._id).lean();
assert.equal(doc1.field, 'value-suffix');

const doc2 = await TestModel.findById(entry._id).lean({ getters: false });
assert.equal(doc2.field, 'value');
```
