### PR TITLE
fix: don't apply getters if defaultLeanOptions is set but lean is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,8 +42,11 @@ function applyGetters(schema, res) {
   if (res == null) {
     return;
   }
+  if (!this._mongooseOptions?.lean) {
+    return;
+  }
   const { defaultLeanOptions } = this._mongooseLeanGettersOptions;
-  const shouldCallGetters = this._mongooseOptions?.lean?.getters ?? defaultLeanOptions?.getters ?? false;
+  const shouldCallGetters = this._mongooseOptions.lean.getters ?? defaultLeanOptions?.getters ?? false;
 
   if (shouldCallGetters) {
     if (Array.isArray(res)) {

--- a/index.js
+++ b/index.js
@@ -42,6 +42,8 @@ function applyGetters(schema, res) {
   if (res == null) {
     return;
   }
+  // Skip applying getters if the `lean` option is false.
+  // This ensures that Mongoose getters are not applied to non-lean queries.
   if (!this._mongooseOptions?.lean) {
     return;
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -442,7 +442,8 @@ describe('mongoose-lean-getters', function() {
     assert.equal(typeof found.discriminatedProp.num, 'string', 'Discriminated prop is not a string');
     assert.equal(typeof found.discriminatedArray[0].num, 'string', 'Discriminated array is not a string');
   });
-  it('allows defaultLeanOptions to be set and overridden at call time (#33)', async() => {
+
+  it('allows defaultLeanOptions to be set and overridden at call time (#33) (#46)', async() => {
     const testSchema = new mongoose.Schema({
       field: {
         type: String,
@@ -458,6 +459,10 @@ describe('mongoose-lean-getters', function() {
 
     const doc2 = await TestModel.findById(entry._id).lean({ getters: false });
     assert.equal(doc2.field, 'value');
+
+    const doc3 = await TestModel.findById(entry._id);
+    assert.equal(doc3.field, 'value-suffix');
+    assert.equal(doc3.get('field', null, { getters: false }), 'value');
   });
 
   it('should allow non-discriminated documents to be retrieved (#39)', async() => {


### PR DESCRIPTION
Fix #46

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#46 points out that setting `defaultLeanOptions: { getters: true }` does apply getters even if `lean` is not set, which can be problematic.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
